### PR TITLE
fix(html-sketchapp): Update html-sketchapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "find-up": "^2.1.0",
     "get-installed-path": "^4.0.8",
     "get-port": "^3.2.0",
-    "html-sketchapp": "github:brainly/html-sketchapp#8f92196695497c722ecbd1a5081833e4c7267d46",
+    "html-sketchapp": "github:brainly/html-sketchapp#413c5a16c9f9f74bab9228f8bf1532d32676f628",
     "mkdirp": "^0.5.1",
     "opn": "^5.1.0",
     "puppeteer": "^0.13.0",

--- a/test/config-file-path/__snapshots__/file.test.js.snap
+++ b/test/config-file-path/__snapshots__/file.test.js.snap
@@ -299,6 +299,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -569,6 +574,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -839,6 +849,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {

--- a/test/config-file/__snapshots__/file.test.js.snap
+++ b/test/config-file/__snapshots__/file.test.js.snap
@@ -299,6 +299,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -569,6 +574,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -839,6 +849,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {

--- a/test/file/__snapshots__/file.test.js.snap
+++ b/test/file/__snapshots__/file.test.js.snap
@@ -299,6 +299,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -569,6 +574,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -839,6 +849,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {

--- a/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
+++ b/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
@@ -299,6 +299,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -569,6 +574,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -839,6 +849,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {

--- a/test/serve/__snapshots__/serve.test.js.snap
+++ b/test/serve/__snapshots__/serve.test.js.snap
@@ -299,6 +299,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -569,6 +574,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -839,6 +849,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {

--- a/test/viewports/__snapshots__/viewports.test.js.snap
+++ b/test/viewports/__snapshots__/viewports.test.js.snap
@@ -319,6 +319,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -589,6 +594,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -859,6 +869,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -1129,6 +1144,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -1399,6 +1419,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {
@@ -1669,6 +1694,11 @@ Object {
                   "thickness": 0,
                 },
               ],
+              "contextSettings": Object {
+                "_class": "graphicsContextSettings",
+                "blendMode": 0,
+                "opacity": "1",
+              },
               "endDecorationType": 0,
               "fills": Array [
                 Object {


### PR DESCRIPTION
Snapshots are updated due to added support for opacity: https://github.com/brainly/html-sketchapp/commit/8be180bdc4c136a21f343e5b6ba21b917ce6cd70