### PR TITLE
fix(puppeteer): Accept Puppeteer args via '--puppeteer-args'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # html-sketchapp-cli
 
-Quickly generate [Sketch libraries](https://www.sketchapp.com/docs/libraries/) from HTML documents and living style guides, powered by [html-sketchapp](https://github.com/brainly/html-sketchapp).
+Quickly generate [Sketch libraries](https://www.sketchapp.com/docs/libraries/) from HTML documents and living style guides, powered by [html-sketchapp](https://github.com/brainly/html-sketchapp) and [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 
 Add some simple markup to your page, for example:
 
@@ -96,6 +96,20 @@ $ html-sketchapp --viewports.Desktop 1024x768 --viewports.Mobile 320x568 --file 
 
 If multiple screen sizes are provided, the viewport name will be being appended to all symbol and text style names. For example, `Button/Primary` will be exported as `Button/Primary/Desktop` and `Button/Primary/Mobile`.
 
+### Puppeteer args
+
+If you need to provide command line arguments to the browser instance via [Puppeteer](https://github.com/GoogleChrome/puppeteer), you can provide the `puppeteer-args` option.
+
+Since Puppeteer uses [Chromium](https://www.chromium.org/Home) internally, you can refer to the [List of Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches) for available options.
+
+For example, if you'd like to disable the browser sandbox:
+
+```bash
+$ html-sketchapp --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --file sketch.html --out-dir dist
+```
+
+*Note: Because Puppeteer args are prefixed with hyphens, you **must** use an equals sign and quotes when providing this option via the command line (as seen above).*
+
 ### Config file
 
 All options can be provided via an `html-sketchapp.config.js` file.
@@ -107,7 +121,8 @@ module.exports = {
   viewports: {
     Desktop: '1024x768',
     Mobile: '320x568'
-  }
+  },
+  puppeteerArgs: '--no-sandbox --disable-setuid-sandbox'
 };
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47,6 +47,10 @@ require('yargs')
     'viewports': {
       alias: 'v',
       describe: 'Set of named viewport sizes for symbols, e.g. --viewports.Desktop=1024x768 --viewports.Mobile=320x568'
+    },
+    'puppeteer-args': {
+      type: 'string',
+      describe: 'Set of command line arguments to be provided to the Chromium instance via Puppeteer, e.g. --puppeteer-args="--no-sandbox --disable-setuid-sandbox"'
     }
   }, async argv => {
     const port = argv.serve ? await getPort() : null;
@@ -57,7 +61,7 @@ require('yargs')
       const symbolsUrl = argv.serve ? urlJoin(`http://localhost:${String(port)}`, argv.url || '/') : url;
       await waitOn({ resources: [symbolsUrl] });
 
-      const browser = await puppeteer.launch();
+      const browser = await puppeteer.launch({ args: argv.puppeteerArgs ? argv.puppeteerArgs.split(' ') : [] });
 
       try {
         const page = await browser.newPage();

--- a/test/config-file-path/custom.config.js
+++ b/test/config-file-path/custom.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   file: 'index.html',
-  outDir: 'dist'
+  outDir: 'dist',
+  puppeteerArgs: '--no-sandbox --disable-setuid-sandbox'
 };

--- a/test/config-file/html-sketchapp.config.js
+++ b/test/config-file/html-sketchapp.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   file: 'index.html',
-  outDir: 'dist'
+  outDir: 'dist',
+  puppeteerArgs: '--no-sandbox --disable-setuid-sandbox'
 };

--- a/test/file/file.test.js
+++ b/test/file/file.test.js
@@ -9,7 +9,7 @@ const distPath = path.join(__dirname, 'dist');
 beforeEach(() => rimrafAsync(distPath));
 
 test('file', async () => {
-  await exec('node ../../bin/cli --out-dir dist --file index.html', { cwd: __dirname });
+  await exec('node ../../bin/cli --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --out-dir dist --file index.html', { cwd: __dirname });
 
   const output = await dirContentsToObject(distPath);
   expect(output).toMatchSnapshot();

--- a/test/serve-with-url/serve-with-url.test.js
+++ b/test/serve-with-url/serve-with-url.test.js
@@ -9,7 +9,7 @@ const distPath = path.join(__dirname, 'dist');
 beforeEach(() => rimrafAsync(distPath));
 
 test('serve-with-url', async () => {
-  await exec('node ../../bin/cli --out-dir dist --serve serve-me --url /another-url', { cwd: __dirname });
+  await exec('node ../../bin/cli --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --out-dir dist --serve serve-me --url /another-url', { cwd: __dirname });
 
   const output = await dirContentsToObject(distPath);
   expect(output).toMatchSnapshot();

--- a/test/serve/serve.test.js
+++ b/test/serve/serve.test.js
@@ -9,7 +9,7 @@ const distPath = path.join(__dirname, 'dist');
 beforeEach(() => rimrafAsync(distPath));
 
 test('serve', async () => {
-  await exec('node ../../bin/cli --out-dir dist --serve serve-me', { cwd: __dirname });
+  await exec('node ../../bin/cli --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --out-dir dist --serve serve-me', { cwd: __dirname });
 
   const output = await dirContentsToObject(distPath);
   expect(output).toMatchSnapshot();

--- a/test/url/url.test.js
+++ b/test/url/url.test.js
@@ -15,7 +15,7 @@ test('url', async () => {
   const port = await getPort();
   const server = serve(servePath, { port, silent: true })
 
-  await exec(`node ../../bin/cli --out-dir dist --url http://localhost:${port}`, { cwd: __dirname });
+  await exec(`node ../../bin/cli --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --out-dir dist --url http://localhost:${port}`, { cwd: __dirname });
 
   server.stop();
 

--- a/test/viewports/viewports.test.js
+++ b/test/viewports/viewports.test.js
@@ -11,6 +11,7 @@ beforeEach(() => rimrafAsync(distPath));
 test('viewports', async () => {
   await exec([
     'node ../../bin/cli',
+    '--puppeteer-args="--no-sandbox --disable-setuid-sandbox"',
     '--out-dir dist',
     '--file index.html',
     '--viewports.Desktop 1024x768',


### PR DESCRIPTION
This fixes an issue where our tests were failing on Travis CI due to browser sandbox issues:

```
Error: Failed to launch chrome!
[0111/012425.923069:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

Since we're only running this tool against local pages that are fully under our control, disabling the sandbox seemed like a reasonable workaround.

Because this issue could also affect consumers of this tool (particularly if they're running it on Travis CI), we now expose the `--puppeteer-args` option publicly and document it in the readme.