### PR TITLE
fix(deps): Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
 before_script:
   - npm prune
 after_success:
-  - npm run semantic-release
+  - npm run travis-deploy-once "npm run semantic-release"
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 const urlJoin = require('url-join');
 const findUp = require('find-up');
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const getPort = require('get-port');
 const serve = require('serve');
 const puppeteer = require('puppeteer');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commit": "git-cz",
     "commitmsg": "commitlint --edit --extends seek",
     "prepublishOnly": "npm run build",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "config": {
     "commitizen": {
@@ -34,20 +34,20 @@
   },
   "homepage": "https://github.com/seek-oss/html-sketchapp-cli#readme",
   "dependencies": {
-    "es6-promisify": "^5.0.0",
+    "es6-promisify": "^6.0.0",
     "find-up": "^2.1.0",
     "get-port": "^3.2.0",
-    "html-sketchapp": "github:brainly/html-sketchapp#413c5a16c9f9f74bab9228f8bf1532d32676f628",
+    "html-sketchapp": "github:brainly/html-sketchapp#49f1d0ea3e239608af0b8f7c0b6240e3a6a331e2",
     "mkdirp": "^0.5.1",
     "opn": "^5.1.0",
-    "puppeteer": "^0.13.0",
-    "serve": "^6.4.1",
-    "url-join": "^2.0.2",
+    "puppeteer": "^1.0.0",
+    "serve": "^6.4.9",
+    "url-join": "^4.0.0",
     "wait-on": "^2.1.0",
-    "yargs": "^10.0.3"
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^5.2.5",
+    "@commitlint/cli": "^6.1.0",
     "child-process-promise": "^2.2.1",
     "commitizen": "^2.9.6",
     "commitlint-config-seek": "^1.0.0",
@@ -57,7 +57,7 @@
     "husky": "^0.14.3",
     "jest": "^22.0.1",
     "rimraf": "^2.6.2",
-    "semantic-release": "^8.2.0",
+    "semantic-release": "^12.4.1",
     "traverse": "^0.6.6",
     "webpack": "^3.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "commit": "git-cz",
     "commitmsg": "commitlint --edit --extends seek",
     "prepublishOnly": "npm run build",
+    "travis-deploy-once": "travis-deploy-once",
     "semantic-release": "semantic-release"
   },
   "config": {
@@ -59,6 +60,7 @@
     "rimraf": "^2.6.2",
     "semantic-release": "^12.4.1",
     "traverse": "^0.6.6",
+    "travis-deploy-once": "^4.3.4",
     "webpack": "^3.10.0"
   }
 }

--- a/test/_utils/dirContentsToObject.js
+++ b/test/_utils/dirContentsToObject.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const path = require('path');
 const readFileAsync = promisify(require('fs').readFile);
 const traverse = require('traverse');

--- a/test/config-file-path/file.test.js
+++ b/test/config-file-path/file.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');

--- a/test/config-file/file.test.js
+++ b/test/config-file/file.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');

--- a/test/file/file.test.js
+++ b/test/file/file.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');

--- a/test/serve-with-url/serve-with-url.test.js
+++ b/test/serve-with-url/serve-with-url.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');

--- a/test/serve/serve.test.js
+++ b/test/serve/serve.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');

--- a/test/url/url.test.js
+++ b/test/url/url.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const getPort = require('get-port');

--- a/test/viewports/viewports.test.js
+++ b/test/viewports/viewports.test.js
@@ -1,4 +1,4 @@
-const promisify = require('es6-promisify');
+const { promisify } = require('es6-promisify');
 const rimrafAsync = promisify(require('rimraf'));
 const path = require('path');
 const { exec } = require('child-process-promise');


### PR DESCRIPTION
Most notably, this PR updates html-sketchapp to [49f1d0ea3e239608af0b8f7c0b6240e3a6a331e2](https://github.com/brainly/html-sketchapp/commit/49f1d0ea3e239608af0b8f7c0b6240e3a6a331e2) and Puppeteer to v1.0.0.