### PR TITLE
feat(puppeteer): Add option to override the Chromium executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ $ html-sketchapp --puppeteer-args="--no-sandbox --disable-setuid-sandbox" --file
 
 *Note: Because Puppeteer args are prefixed with hyphens, you **must** use an equals sign and quotes when providing this option via the command line (as seen above).*
 
+### Chromium executable
+
+If you'd like to override the Chromium used by Puppeteer, you can provide a path to the executable with the `puppeteer-executable-path` option.
+
+```bash
+$ html-sketchapp --puppeteer-executable-path google-chrome-unstable --file sketch.html --out-dir dist
+```
+
 ### Config file
 
 All options can be provided via an `html-sketchapp.config.js` file.
@@ -122,7 +130,8 @@ module.exports = {
     Desktop: '1024x768',
     Mobile: '320x568'
   },
-  puppeteerArgs: '--no-sandbox --disable-setuid-sandbox'
+  puppeteerArgs: '--no-sandbox --disable-setuid-sandbox',
+  puppeteerExecutablePath: 'google-chrome-unstable'
 };
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,6 +51,10 @@ require('yargs')
     'puppeteer-args': {
       type: 'string',
       describe: 'Set of command line arguments to be provided to the Chromium instance via Puppeteer, e.g. --puppeteer-args="--no-sandbox --disable-setuid-sandbox"'
+    },
+    'puppeteer-executable-path': {
+      type: 'string',
+      describe: 'Path to a Chromium executable to use instead of the one downloaded by Puppeteer.'
     }
   }, async argv => {
     try {
@@ -68,7 +72,11 @@ require('yargs')
           resources: [symbolsUrl.replace(/^(https?)/, '$1-get')],
         });
 
-        const browser = await puppeteer.launch({ args: argv.puppeteerArgs ? argv.puppeteerArgs.split(' ') : [] });
+        const launchArgs = {
+            args: argv.puppeteerArgs ? argv.puppeteerArgs.split(' ') : [],
+            executablePath: argv.puppeteerExecutablePath,
+        };
+        const browser = await puppeteer.launch(launchArgs);
 
         try {
           const page = await browser.newPage();


### PR DESCRIPTION
Hi! Thanks for releasing this tool!

For my use-case, I'd like to be able to run html-sketchapp-cli in a Docker container and not rely on Puppeteer downloading the appropriate Chromium binary on install. Puppeteer [provides an option](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker) to use a different Chromium (you can specify an arbitrary executablePath), but since this tool is wrapping puppeteer, the option needs to be passed through.

This branch adds a new command-line option (`--puppeteer-executable-path`) to html-sketchapp-cli, which will be passed through to Puppeteer as the executablePath. This allows us to run without the bundled Chromium like so:

```bash
$ PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn add html-sketchapp-cli
$ html-sketchapp --puppeteer-executable-path google-chrome-unstable --file sketch.html --out-dir dist
```