### PR TITLE
fix(install): Use scoped package in install command

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -132,7 +132,7 @@ require('yargs')
     }
   })
   .command('install', 'Install the html-sketchapp Sketch plugin', {}, () => {
-    const htmlSketchappPath = path.dirname(require.resolve('html-sketchapp/package.json'));
+    const htmlSketchappPath = path.dirname(require.resolve('@brainly/html-sketchapp/package.json'));
     const pluginPath = path.resolve(htmlSketchappPath, 'asketch2sketch.sketchplugin');
 
     const opn = require('opn');


### PR DESCRIPTION
The install command was broken in v0.1.1 because html-sketchapp is now a scoped package, under `@brainly`, but the `require.resolve` call in the install command wasn't updated.