### PR TITLE
fix(deps): Update html-sketchapp-cli to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/seek-oss/html-sketchapp-cli#readme",
   "dependencies": {
-    "@brainly/html-sketchapp": "^1.1.0",
+    "@brainly/html-sketchapp": "^2.0.0",
     "es6-promisify": "^6.0.0",
     "find-up": "^2.1.0",
     "get-port": "^3.2.0",
@@ -58,9 +58,10 @@
     "husky": "^0.14.3",
     "jest": "^22.0.1",
     "rimraf": "^2.6.2",
-    "semantic-release": "^12.4.1",
+    "semantic-release": "^15.1.3",
     "traverse": "^0.6.6",
     "travis-deploy-once": "^4.3.4",
-    "webpack": "^3.10.0"
+    "webpack": "^4.1.1",
+    "webpack-cli": "^2.0.12"
   }
 }

--- a/script/src/webpack.config.js
+++ b/script/src/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  mode: 'production',
   entry: path.resolve(__dirname, 'generateAlmostSketch.js'),
   output: {
     path: __dirname,


### PR DESCRIPTION
html-sketchapp's `nodeToSketchLayers` function is no longer async, so a lot of our consuming code is no longer async either. Luckily, since the changes didn't have any impact on our tests, this doesn't impact our consumers.

While I was at it, I also updated our dev dependencies—namely webpack and semantic-release.