### PR TITLE
feat(debug): Add debug mode via '--debug' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ $ html-sketchapp --viewports.HigherDensity 1024x768@1.5 --viewports.Retina 1024x
 
 If no scaling factor is provided, a default of `1` will be used.
 
+### Debug mode
+
+If you need to see what puppeteer is doing you can add the debug flag to enable the following things:
+- Turn off headless mode
+- Bring the browser window to the front
+- Forward `console` calls to the terminal
+- Stop the browser from closing until you exit the cli tool
+
+```bash
+$ html-sketchapp --url http://localhost:3000 --out-dir dist --debug
+```
+
 ### Puppeteer args
 
 If you need to provide command line arguments to the browser instance via [Puppeteer](https://github.com/GoogleChrome/puppeteer), you can provide the `puppeteer-args` option.

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ If no scaling factor is provided, a default of `1` will be used.
 
 ### Debug mode
 
-If you need to see what puppeteer is doing you can add the debug flag to enable the following things:
+If you need to see what Puppeteer is doing, you can provide the `--debug` flag which will do the following things:
 - Turn off headless mode
 - Bring the browser window to the front
 - Forward `console` calls to the terminal
-- Stop the browser from closing until you exit the cli tool
+- Stop the browser from closing until you exit the CLI tool
+
+For example:
 
 ```bash
 $ html-sketchapp --url http://localhost:3000 --out-dir dist --debug


### PR DESCRIPTION
Had a tricky to debug issue and found this helpful to debug what was happening in puppeteer when it was launched.

Does four things:

- Turns off headless mode
- Brings the browser to the front
- Forwards on `console` calls to terminal
- Stops the browser from closing