### PR TITLE
chore(renovate): Disable dependency version pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "seek"
   ],
+  "pinVersions": false,
   "packageRules": [
     {
       "packageNames": ["@brainly/html-sketchapp"],


### PR DESCRIPTION
Since this is a library, we want our dependencies to stay up to date automatically based on the version ranges in `package.json`.