### PR TITLE
chore(renovate): Fix ‘pinVersions’ config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "extends": [
     "seek"
   ],
-  "pinVersions": false,
+  "dependencies": {
+    "pinVersions": false
+  },
   "packageRules": [
     {
       "packageNames": ["@brainly/html-sketchapp"],


### PR DESCRIPTION
Our `pinVersions` override is currently less specific than the `dependencies.pinVersions` value defined in [renovate-config-seek](https://github.com/seek-oss/renovate-config-seek), so this fixes it.