### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ after_success:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis clones the last 50 commits. Cloning 5 is faster and sufficient.

See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth