### PR TITLE
fix(install): Update install command to use new release URL format

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -179,7 +179,8 @@ require('yargs')
     await rimrafAsync(tmpDirPath);
     await mkdirpAsync(tmpDirPath);
 
-    const releaseUrl = `http://github.com/brainly/html-sketchapp/releases/download/v${version}/asketch2sketch.sketchplugin.zip`;
+    const [ major, minor, patch ] = version.split('.');
+    const releaseUrl = `http://github.com/brainly/html-sketchapp/releases/download/v${version}/asketch2sketch-${major}-${minor}-${patch}.sketchplugin.zip`;
     console.log(`Downloading from ${releaseUrl}`);
     const axios = require('axios');
     const { data } = await axios(releaseUrl, { responseType: 'arraybuffer' });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/seek-oss/html-sketchapp-cli#readme",
   "dependencies": {
-    "@brainly/html-sketchapp": "^3.0.0",
+    "@brainly/html-sketchapp": "^3.2.0",
     "axios": "^0.18.0",
     "decompress": "^4.2.0",
     "es6-promisify": "^6.0.0",

--- a/test/config-file-path/__snapshots__/file.test.js.snap
+++ b/test/config-file-path/__snapshots__/file.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/config-file/__snapshots__/file.test.js.snap
+++ b/test/config-file/__snapshots__/file.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/file/__snapshots__/file.test.js.snap
+++ b/test/file/__snapshots__/file.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/nested-symbols/__snapshots__/nested-symbols.test.js.snap
+++ b/test/nested-symbols/__snapshots__/nested-symbols.test.js.snap
@@ -29,6 +29,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -46,6 +47,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -68,6 +70,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -86,6 +89,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -130,6 +134,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -148,6 +153,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -268,6 +274,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -285,6 +292,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -340,6 +348,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -358,6 +367,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -402,6 +412,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -420,6 +431,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -540,6 +552,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -557,6 +570,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -612,6 +626,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -630,6 +645,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -646,6 +662,7 @@ Object {
         "layers": Array [
           Object {
             "_class": "symbolInstance",
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "exportOptions": Object {
               "_class": "exportOptions",
@@ -662,6 +679,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -684,6 +702,7 @@ Object {
           },
           Object {
             "_class": "symbolInstance",
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "exportOptions": Object {
               "_class": "exportOptions",
@@ -700,6 +719,7 @@ Object {
               "x": 0,
               "y": 18,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -751,6 +771,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -769,6 +790,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -813,6 +835,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -831,6 +854,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -951,6 +975,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -968,6 +993,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1023,6 +1049,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1041,6 +1068,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1085,6 +1113,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1103,6 +1132,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1223,6 +1253,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1240,6 +1271,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1295,6 +1327,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1313,6 +1346,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1329,6 +1363,7 @@ Object {
         "layers": Array [
           Object {
             "_class": "symbolInstance",
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "exportOptions": Object {
               "_class": "exportOptions",
@@ -1345,6 +1380,7 @@ Object {
               "x": 0,
               "y": 0,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1367,6 +1403,7 @@ Object {
           },
           Object {
             "_class": "symbolInstance",
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "exportOptions": Object {
               "_class": "exportOptions",
@@ -1383,6 +1420,7 @@ Object {
               "x": 0,
               "y": 18,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
+++ b/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/serve/__snapshots__/serve.test.js.snap
+++ b/test/serve/__snapshots__/serve.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/symbol-layer-middleware/__snapshots__/symbol-layer-middleware.test.js.snap
+++ b/test/symbol-layer-middleware/__snapshots__/symbol-layer-middleware.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1055,6 +1075,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -1072,6 +1093,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -1094,6 +1116,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1112,6 +1135,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1156,6 +1180,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1174,6 +1199,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1294,6 +1320,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1311,6 +1338,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1366,6 +1394,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1384,6 +1413,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1428,6 +1458,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1446,6 +1477,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1566,6 +1598,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1583,6 +1616,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1638,6 +1672,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1656,6 +1691,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1700,6 +1736,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1718,6 +1755,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1838,6 +1876,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1855,6 +1894,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/url/__snapshots__/url.test.js.snap
+++ b/test/url/__snapshots__/url.test.js.snap
@@ -94,6 +94,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -111,6 +112,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -133,6 +135,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -151,6 +154,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -195,6 +199,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -213,6 +218,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -333,6 +339,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -350,6 +357,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -405,6 +413,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -423,6 +432,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -467,6 +477,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -485,6 +496,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -605,6 +617,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -622,6 +635,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -677,6 +691,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -695,6 +710,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -739,6 +755,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -757,6 +774,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -877,6 +895,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -894,6 +913,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,

--- a/test/viewports/__snapshots__/viewports.test.js.snap
+++ b/test/viewports/__snapshots__/viewports.test.js.snap
@@ -156,6 +156,7 @@ Object {
   },
   "document.page.json": Object {
     "_class": "page",
+    "clippingMaskMode": 0,
     "do_objectID": "__GUID__",
     "exportOptions": Object {
       "_class": "exportOptions",
@@ -173,6 +174,7 @@ Object {
       "y": 0,
     },
     "hasClickThrough": true,
+    "hasClippingMask": false,
     "horizontalRulerData": Object {
       "_class": "rulerData",
       "base": 0,
@@ -195,6 +197,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -213,6 +216,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -257,6 +261,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -275,6 +280,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -395,6 +401,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -412,6 +419,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -467,6 +475,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -485,6 +494,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -529,6 +539,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -547,6 +558,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -667,6 +679,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -684,6 +697,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -739,6 +753,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -757,6 +772,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -801,6 +817,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -819,6 +836,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -939,6 +957,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -956,6 +975,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1011,6 +1031,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1029,6 +1050,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1073,6 +1095,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1091,6 +1114,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1211,6 +1235,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1228,6 +1253,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1283,6 +1309,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1301,6 +1328,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1345,6 +1373,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1363,6 +1392,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1483,6 +1513,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1500,6 +1531,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1555,6 +1587,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1573,6 +1606,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1617,6 +1651,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1635,6 +1670,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -1755,6 +1791,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -1772,6 +1809,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -1827,6 +1865,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -1845,6 +1884,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -1889,6 +1929,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -1907,6 +1948,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -2027,6 +2069,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -2044,6 +2087,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -2099,6 +2143,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -2117,6 +2162,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -2161,6 +2207,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -2179,6 +2226,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -2299,6 +2347,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -2316,6 +2365,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -2371,6 +2421,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -2389,6 +2440,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -2433,6 +2485,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -2451,6 +2504,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -2571,6 +2625,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -2588,6 +2643,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -2643,6 +2699,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -2661,6 +2718,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -2705,6 +2763,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -2723,6 +2782,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -2843,6 +2903,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -2860,6 +2921,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -2915,6 +2977,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -2933,6 +2996,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -2977,6 +3041,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -2995,6 +3060,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -3115,6 +3181,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -3132,6 +3199,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,
@@ -3187,6 +3255,7 @@ Object {
           "red": 1,
         },
         "changeIdentifier": 0,
+        "clippingMaskMode": 0,
         "do_objectID": "__GUID__",
         "exportOptions": Object {
           "_class": "exportOptions",
@@ -3205,6 +3274,7 @@ Object {
         },
         "hasBackgroundColor": false,
         "hasClickThrough": true,
+        "hasClippingMask": false,
         "horizontalRulerData": Object {
           "_class": "rulerData",
           "base": 0,
@@ -3249,6 +3319,7 @@ Object {
               Object {
                 "_class": "rectangle",
                 "booleanOperation": -1,
+                "clippingMaskMode": 0,
                 "do_objectID": "__GUID__",
                 "edited": false,
                 "exportOptions": Object {
@@ -3267,6 +3338,7 @@ Object {
                   "x": 0,
                   "y": 0,
                 },
+                "hasClippingMask": false,
                 "hasConvertedToNewRoundCorners": true,
                 "isFlippedHorizontal": false,
                 "isFlippedVertical": false,
@@ -3387,6 +3459,7 @@ Object {
           Object {
             "_class": "text",
             "automaticallyDrawOnUnderlyingPath": false,
+            "clippingMaskMode": 0,
             "do_objectID": "__GUID__",
             "dontSynchroniseWithSymbol": false,
             "exportOptions": Object {
@@ -3404,6 +3477,7 @@ Object {
               "x": 20,
               "y": 10,
             },
+            "hasClippingMask": false,
             "isFlippedHorizontal": false,
             "isFlippedVertical": false,
             "isLocked": false,


### PR DESCRIPTION
As of [v3.2.0](https://github.com/brainly/html-sketchapp/releases/tag/v3.2.0), html-sketchapp has a new release URL format which breaks our `install` command. This PR updates the logic for generating the download URL, and also updates the minimum supported version to v3.2.0 in our package.json.

(Ping @kdzwinel)

Update: Also had to update the snapshots to match the latest version of html-sketchapp.