### PR TITLE
test: Fix Jest localStorage warning, fix invalid hex codes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
 module.exports = {
-  setupTestFrameworkScriptFile: path.resolve(__dirname, 'test/_utils/jestSetup.js')
+  setupTestFrameworkScriptFile: path.resolve(__dirname, 'test/_utils/jestSetup.js'),
+  testEnvironment: 'node'
 };

--- a/test/config-file-path/__snapshots__/file.test.js.snap
+++ b/test/config-file-path/__snapshots__/file.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/config-file-path/index.html
+++ b/test/config-file-path/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/config-file/__snapshots__/file.test.js.snap
+++ b/test/config-file/__snapshots__/file.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/config-file/index.html
+++ b/test/config-file/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/file/__snapshots__/file.test.js.snap
+++ b/test/file/__snapshots__/file.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/file/index.html
+++ b/test/file/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
+++ b/test/serve-with-url/__snapshots__/serve-with-url.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/serve-with-url/serve-me/another-url/index.html
+++ b/test/serve-with-url/serve-me/another-url/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/serve/__snapshots__/serve.test.js.snap
+++ b/test/serve/__snapshots__/serve.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/serve/serve-me/index.html
+++ b/test/serve/serve-me/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/symbol-layer-middleware/__snapshots__/symbol-layer-middleware.test.js.snap
+++ b/test/symbol-layer-middleware/__snapshots__/symbol-layer-middleware.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",
@@ -990,10 +990,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/symbol-layer-middleware/index.html
+++ b/test/symbol-layer-middleware/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/symbol-middleware/__snapshots__/symbol-middleware.test.js.snap
+++ b/test/symbol-middleware/__snapshots__/symbol-middleware.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",
@@ -990,10 +990,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/symbol-middleware/index.html
+++ b/test/symbol-middleware/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>

--- a/test/url/__snapshots__/url.test.js.snap
+++ b/test/url/__snapshots__/url.test.js.snap
@@ -9,10 +9,10 @@ Object {
       "colors": Array [
         Object {
           "_class": "color",
-          "alpha": 0,
+          "alpha": 1,
           "blue": 0,
           "green": 0,
-          "red": 0,
+          "red": 1,
         },
         Object {
           "_class": "color",

--- a/test/url/index.html
+++ b/test/url/index.html
@@ -27,7 +27,7 @@
     <div data-sketch-text="Text 2"><h2>Text 2</h2></div>
     <div data-sketch-text="Text 3"><h3>Text 3</h3></div>
 
-    <div data-sketch-color="#ff000" class="color red">Color 1</div>
+    <div data-sketch-color="#ff0000" class="color red">Color 1</div>
     <div data-sketch-color="#00ff00" class="color green">Color 2</div>
     <div data-sketch-color="#0000ff" class="color blue">Color 3</div>
   </body>


### PR DESCRIPTION
I was trying to investigate a potential issue with `data-sketch-color`, but immediately ran into issues where the test suite was failing with the following message:

```
SecurityError: localStorage is not available for opaque origins
```

The fix was to set `testEnvironment` to `node` in the Jest config.

After fixing this, I noticed that we actually had some invalid hex codes in our test suite, which was resulting in unexpected document colours. I've update the hex codes and the snapshots, and verified that the colours show up correctly when importing into Sketch.

Luckily, as far as `data-sketch-color` goes, I wasn't able to find any issues.