### PR TITLE
feat(ids): Support custom IDs for Sketch library sync

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -129,7 +129,7 @@ require('yargs')
 
           await page.addScriptTag({ content: code });
 
-          await page.evaluate(`generateAlmostSketch.setupSymbols({ ${argv.name ? `id: ${argv.name}, ` : ''}name: "html-sketchapp symbols" })`);
+          await page.evaluate(`generateAlmostSketch.setupSymbols({ ${argv.name ? `id: '${argv.name}', ` : ''}name: "html-sketchapp symbols" })`);
 
           await page.evaluate('generateAlmostSketch.snapshotColorStyles()');
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -129,7 +129,7 @@ require('yargs')
 
           await page.addScriptTag({ content: code });
 
-          await page.evaluate('generateAlmostSketch.setupSymbols({ name: "html-sketchapp symbols" })');
+          await page.evaluate(`generateAlmostSketch.setupSymbols({ ${argv.name ? `id: ${argv.name}, ` : ''}name: "html-sketchapp symbols" })`);
 
           await page.evaluate('generateAlmostSketch.snapshotColorStyles()');
 
@@ -142,12 +142,12 @@ require('yargs')
               const [ width, height ] = size.split('x').map(x => parseInt(x, 10));
               const deviceScaleFactor = typeof scale === 'undefined' ? 1 : parseFloat(scale);
               await page.setViewport({ width, height, deviceScaleFactor });
-              await page.evaluate(`generateAlmostSketch.snapshotTextStyles({ suffix: "${hasViewports ? `/${viewportName}` : ''}" })`);
+              await page.evaluate(`generateAlmostSketch.snapshotTextStyles({ ${argv.customIds ? 'customIds: true, ' : ''}suffix: "${hasViewports ? `/${viewportName}` : ''}" })`);
               await page.evaluate(`generateAlmostSketch.snapshotSymbols({ suffix: "${hasViewports ? `/${viewportName}` : ''}", symbolLayerMiddleware: ${symbolLayerMiddleware}, symbolMiddleware: ${symbolMiddleware}, symbolInstanceMiddleware: ${symbolInstanceMiddleware}  })`);
             }
           }
 
-          const asketchDocumentJSON = await page.evaluate('generateAlmostSketch.getDocumentJSON()');
+          const asketchDocumentJSON = await page.evaluate(`generateAlmostSketch.getDocumentJSON('${argv.name || ''}')`);
           const asketchPageJSON = await page.evaluate('generateAlmostSketch.getPageJSON()');
 
           const outputPath = path.resolve(process.cwd(), argv.outDir);

--- a/script/generateAlmostSketch.js
+++ b/script/generateAlmostSketch.js
@@ -59,7 +59,7 @@ export function snapshotColorStyles() {
     });
 }
 
-export function snapshotTextStyles({ suffix = '' }) {
+export function snapshotTextStyles({ suffix = '', customIds }) {
   Array.from(document.querySelectorAll('[data-sketch-text]'))
     .forEach(node => {
       getAllLayers(node)
@@ -67,13 +67,21 @@ export function snapshotTextStyles({ suffix = '' }) {
         .forEach(layer => {
           const name = node.dataset.sketchText;
 
-          layer.setName(`${name}${suffix}`);
-          doc.addTextStyle(layer);
+          const id = `${name}${suffix}`;
+          layer.setName(id);
+          if (customIds) {
+            doc.addTextStyle(layer, id);
+          } else {
+            doc.addTextStyle(layer);
+          }
         });
     });
 }
 
-export function getDocumentJSON() {
+export function getDocumentJSON(name) {
+  if (name) {
+    doc.setId(name);
+  }
   return JSON.stringify(doc.toJSON());
 }
 
@@ -82,7 +90,10 @@ const page = new Page({
   height: document.body.offsetHeight
 });
 
-export function setupSymbols({ name }) {
+export function setupSymbols({ name, id }) {
+  if (id) {
+    page.setId(id);
+  }
   page.setName(name);
 }
 


### PR DESCRIPTION
This adds a document/page name option in the config together with a `customIds` opt-in option that uses permanent IDs for shared styles in `html-sketchapp` if you know all IDs (`data-sketch-text`) are unique and will not change.

This PR should fix library sync between updates (symbols can have a permanent ID).

Documentation should probably be added to the `README.md` for setting symbol IDs:
```js
  symbolMiddleware: ({ symbol, node, suffix }) => {
    const symbolName = node.dataset.sketchSymbol;

    symbol.setId(`${symbolName}${suffix}`);
    symbol.setName(symbolName);
  },
```

New config options:
```js
{
  name: 'project-id-here',
  customIds: true
}
```

Depends on changes in https://github.com/brainly/html-sketchapp/pull/151 (that would need to be merged first).

#18 