### PR TITLE
feat(puppeteer): Add User Data Dir puppeteer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ module.exports = {
     Mobile: '320x568'
   },
   puppeteerArgs: '--no-sandbox --disable-setuid-sandbox',
-  puppeteerExecutablePath: 'google-chrome-unstable'
+  puppeteerExecutablePath: 'google-chrome-unstable',
+  pupperteerUserDataDir: '/home/corn/.config/google-chrome/Default' // https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/docs/api.md#puppeteerdefaultargsoptions
 };
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -76,6 +76,10 @@ require('yargs')
       type: 'string',
       describe: 'Path to a Chromium executable to use instead of the one downloaded by Puppeteer.'
     },
+    'puppeteer-user-data-dir': {
+      type: 'string',
+      describe: 'Path to a Chromium User Data directory to use instead of the blank temporary one used by Puppeteer.'
+    },
     'puppeteer-wait-until': {
       type: 'string',
       describe: 'The Puppeteer navigation event to use before considering the page loaded.',
@@ -99,7 +103,8 @@ require('yargs')
         const launchArgs = {
             args: argv.puppeteerArgs ? argv.puppeteerArgs.split(' ') : [],
             executablePath: argv.puppeteerExecutablePath,
-            headless: !debug
+            headless: !debug,
+            userDataDir: argv.puppeteerUserDataDir
         };
 
         const browser = await puppeteer.launch(launchArgs);


### PR DESCRIPTION
Now there is an option called "puppeteerUserDataDir" which allows the user to specify a path to the Chrome User Data Directory they would like to use.